### PR TITLE
#90: keep ffinput options local

### DIFF
--- a/ffcode.dtx
+++ b/ffcode.dtx
@@ -333,10 +333,10 @@
 % \begin{macro}{ffinput}
 % Then, we define the \texttt{\char`\\ffinput} command:
 % \changes{v0.10.0}{2024/12/29}{The \texttt{\char`\\ffinput} command added.}
+% \changes{v0.12.0}{2026/05/26}{Stopped \texttt{\char`\\ffinput} options from leaking into later listings.}
 %    \begin{macrocode}
 \makeatletter
 \newcommand\ffinput[2][]{%
-  \ff@set{#1}%
   \ifdefined\ff@samepage\noindent\minipage{\linewidth}\fi%
   \lstinputlisting[#1]{#2}%
   \ifdefined\ff@samepage\endminipage\fi%

--- a/testfiles/ffinput-options.luatex.tlg
+++ b/testfiles/ffinput-options.luatex.tlg
@@ -1,0 +1,4 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+(ffinput-options.lvt)
+ffinput options are local

--- a/testfiles/ffinput-options.lvt
+++ b/testfiles/ffinput-options.lvt
@@ -1,0 +1,25 @@
+% SPDX-FileCopyrightText: Copyright (c) 2021-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+\input{regression-test.tex}
+\documentclass{article}
+\usepackage[nobars]{ffcode}
+\newcount\ffinputstyled
+\newcount\ffinputafter
+\begin{document}
+\START
+
+\ffinput[basicstyle={\ttfamily\global\advance\ffinputstyled by 1\relax}]{ffinput-options.lvt}
+\ffinputafter=\ffinputstyled
+
+\begin{ffcode}
+Listing after ffinput
+\end{ffcode}
+
+\ifnum\ffinputstyled=\ffinputafter
+  \TYPE{ffinput options are local}
+\else
+  \TYPE{ffinput options leaked}
+\fi
+
+\END

--- a/testfiles/ffinput-options.tlg
+++ b/testfiles/ffinput-options.tlg
@@ -1,0 +1,4 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+(ffinput-options.lvt)
+ffinput options are local

--- a/testfiles/ffinput-options.xetex.tlg
+++ b/testfiles/ffinput-options.xetex.tlg
@@ -1,0 +1,4 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+(ffinput-options.lvt)
+ffinput options are local


### PR DESCRIPTION
Fixes #90.

What changed:
- Removed the `\ff@set{#1}` call from `\ffinput`; `\lstinputlisting[#1]` already applies those options to the current listing.
- Added a regression that applies a `basicstyle` side effect through `\ffinput`, records the counter, and verifies a following `ffcode` block does not inherit it.
- Added the package changelog entry for the fix.

Validation:
- `l3build check --engine pdftex --show-log-on-error --halt-on-error` (Kali host)
- `typos ffcode.dtx README.md build.lua testfiles`
- `uvx reuse lint`
- `uvx yamllint .github/workflows/*.yml`
- `npx --yes markdownlint-cli2 README.md`
- `git diff --check upstream/master...HEAD`
- `git diff upstream/master...HEAD --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --exit-code 1` (Kali host)

Limitations:
- `l3build ctan --show-log-on-error --halt-on-error` could not complete on the Kali TeX Live 2026/Debian host: the existing LuaTeX `ffinput` baseline emits extra font-loading lines locally, and a direct XeTeX check cannot find `xelatex.fmt`. The full pdfTeX regression suite passes.
- This macOS host does not have `l3build`, `pdflatex`, `luatex`, or `xetex` installed; TeX engine matrix validation is left to GitHub Actions.

No secrets included.