### PR TITLE
Create missing parent directory for ffsave target

### DIFF
--- a/.github/workflows/l3build.yml
+++ b/.github/workflows/l3build.yml
@@ -14,9 +14,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TERM: xterm-256color
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-15]
+        os: [ubuntu-24.04, macos-15, windows-2025]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
@@ -26,6 +29,8 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
       - run: brew install ghostscript
         if: matrix.os == 'macos-15'
+      - run: choco install --yes --no-progress ghostscript
+        if: matrix.os == 'windows-2025'
       - run: sed -E 's/^(hard|soft)[[:space:]]+//' DEPENDS.txt > .texlive-packages.txt
       - uses: zauguin/install-texlive@v4.4.0
         with:

--- a/.github/workflows/l3build.yml
+++ b/.github/workflows/l3build.yml
@@ -37,6 +37,9 @@ jobs:
           package_file: .texlive-packages.txt
           texlive_version: 2025
       - run: l3build ctan --show-log-on-error --halt-on-error
+        if: matrix.os != 'windows-2025'
+      - run: l3build check --show-log-on-error --halt-on-error
+        if: matrix.os == 'windows-2025'
       - if: failure()
         run: |
           echo '::group::ffcode.log'

--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -1,7 +1,6 @@
 hard fancyvrb
 hard listings
 hard pgfopts
-hard shellesc
 hard tcolorbox
 hard xcolor
 soft docshots
@@ -19,6 +18,6 @@ soft pdfcrop
 soft pgf
 soft scheme-basic
 soft silence
-soft tools
+hard tools
 soft upquote
 soft xetex

--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -1,6 +1,7 @@
 hard fancyvrb
 hard listings
 hard pgfopts
+hard shellesc
 hard tcolorbox
 hard xcolor
 soft docshots

--- a/ffcode.dtx
+++ b/ffcode.dtx
@@ -346,13 +346,24 @@
 % \end{macro}
 
 % \begin{macro}{ffsave}
-% Then, we define the \texttt{ffsave} environment:
+% Then, we define the \texttt{ffsave} environment. Before opening the
+% output stream, its missing parent directory is created, so that
+% \texttt{\char`\\begin\char`\{ffsave\char`\}[foo/bar.txt]}
+% works even when \texttt{foo/} is absent (this needs shell escape enabled):
 % \changes{v0.11.0}{2025/07/06}{The \texttt{ffsave} environment added.}
+% \changes{v0.12.1}{2026/07/10}{The \texttt{ffsave} environment now creates the missing parent directory of its target file.}
 %    \begin{macrocode}
 \RequirePackage{fancyvrb}
+\RequirePackage{shellesc}
+\makeatletter
 \newenvironment{ffsave}[1][ffsave.txt]
-  {\VerbatimEnvironment\begin{VerbatimOut}{#1}}
+  {\filename@parse{#1}%
+   \ifx\filename@area\@empty\else
+     \ShellEscape{mkdir -p "\filename@area"}%
+   \fi
+   \VerbatimEnvironment\begin{VerbatimOut}{#1}}
   {\end{VerbatimOut}}
+\makeatother
 %    \end{macrocode}
 % \end{macro}
 

--- a/ffcode.dtx
+++ b/ffcode.dtx
@@ -356,10 +356,22 @@
 \RequirePackage{fancyvrb}
 \RequirePackage{shellesc}
 \makeatletter
+\ExplSyntaxOn
+\cs_new_protected:cpn { ff@mkdir } #1
+  {
+    \str_set:Nn \l_tmpa_str {#1}
+    \sys_if_platform_windows:TF
+      {
+        \str_replace_all:Nnn \l_tmpa_str { / } { \c_backslash_str }
+        \ShellEscape { if~not~exist~"\l_tmpa_str"~mkdir~"\l_tmpa_str" }
+      }
+      { \ShellEscape { mkdir~-p~"\l_tmpa_str" } }
+  }
+\ExplSyntaxOff
 \newenvironment{ffsave}[1][ffsave.txt]
   {\filename@parse{#1}%
    \ifx\filename@area\@empty\else
-     \ShellEscape{mkdir -p "\filename@area"}%
+     \expandafter\ff@mkdir\expandafter{\filename@area}%
    \fi
    \VerbatimEnvironment\begin{VerbatimOut}{#1}}
   {\end{VerbatimOut}}


### PR DESCRIPTION
The `ffsave` environment writes its content through fancyvrb's `VerbatimOut`, which relies on TeX's `\openout`. That primitive never creates directories, so `\begin{ffsave}[foo/bar.txt]` fails with a fatal error when `foo/` does not exist.

This parses the target path with the kernel's `\filename@parse` and, when it has a directory part, creates it before the output stream is opened. Creation is platform-aware: `mkdir -p` on Unix, and on Windows the separators are translated to backslashes and the idempotent `if not exist ... mkdir ...` idiom is used, since cmd.exe has no `-p` flag. Platform detection uses expl3's `\sys_if_platform_windows:TF`, so no extra package is pulled in beyond `shellesc`. Targets without a directory (the `ffsave.txt` default) are left untouched.

Directory creation needs shell escape enabled, which the package build already turns on. `shellesc` is now declared as a hard dependency. The Unix path is verified end to end; the Windows branch follows the standard cmd.exe idioms but I could not exercise it here.

Closes #99