### PR TITLE
Stop acmart from warning about vertical spacing in ffcode blocks

### DIFF
--- a/ffcode.dtx
+++ b/ffcode.dtx
@@ -296,7 +296,8 @@
 % \texttt{acmart} warns about the \texttt{\char`\\@vspace} that \texttt{listings} emits around displays; restore its saved originals during typesetting:
 \ifdefined\@vspace@orig
   \lst@AddToHook{DisplayStyle}{%
-    \let\@vspace\@vspace@orig\let\@vspacer\@vspacer@orig}
+    \let\@vspace\@vspace@orig
+    \ifdefined\@vspacer@orig\let\@vspacer\@vspacer@orig\fi}
 \fi
 \lstset{breaklines}
 \lstset{escapeinside={(*@}{@*)}}

--- a/ffcode.dtx
+++ b/ffcode.dtx
@@ -287,11 +287,17 @@
 % \changes{v0.9.0}{2024/01/09}{The \texttt{minted} package is replaced by the \texttt{listings} package.}
 % \changes{v0.10.2}{2025/07/06}{We started to use \texttt{keepspaces} in order to guarantee correct visual rendering of multi-spaced content.}
 % \changes{v0.12.0}{2026/05/05}{Static \texttt{\char`\\lstset} defaults moved from the per-environment hook to the preamble, so that user-supplied \texttt{\char`\\lstset} calls are no longer overwritten on every \texttt{ffcode} usage.}
+% \changes{v0.12.2}{2026/07/10}{Restore the original \texttt{\char`\\@vspace} inside listings, so \texttt{acmart} no longer warns about the vertical spacing that \texttt{listings} emits around every block.}
 %    \begin{macrocode}
 \RequirePackage{listings}
 \makeatletter
 % See \href{https://tex.stackexchange.com/questions/706858}{the explanation}:
 \lst@AddToHook{Init}{\setlength{\lineskip}{0pt}}
+% \texttt{acmart} warns about the \texttt{\char`\\@vspace} that \texttt{listings} emits around displays; restore its saved originals during typesetting:
+\ifdefined\@vspace@orig
+  \lst@AddToHook{DisplayStyle}{%
+    \let\@vspace\@vspace@orig\let\@vspacer\@vspacer@orig}
+\fi
 \lstset{breaklines}
 \lstset{escapeinside={(*@}{@*)}}
 \lstset{basicstyle={\ttfamily}}

--- a/testfiles/acmart.lvt
+++ b/testfiles/acmart.lvt
@@ -1,0 +1,29 @@
+% SPDX-FileCopyrightText: Copyright (c) 2021-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+% This test emulates the \vspace guard that acmart installs (its
+% \@vspace@orig machinery, see acmart.cls) instead of loading the whole
+% class, so that the expected log stays small and stable across TeX Live
+% versions. It fails when ffcode lets listings trip that guard (issue #102).
+
+\input{regression-test.tex}
+\documentclass{article}
+\usepackage{etoolbox}
+\makeatletter
+\let\@vspace@orig=\@vspace
+\let\@vspacer@orig=\@vspacer
+\apptocmd{\@vspace}{\ClassWarning{acmart}{\string\vspace\space should only be used}}{}{}
+\apptocmd{\@vspacer}{\ClassWarning{acmart}{\string\vspace\space should only be used}}{}{}
+\makeatother
+\usepackage[nocn,nonumbers,noframes]{ffcode}
+\begin{document}
+
+\START
+
+\begin{ffcode}
+int fibo(int n) {
+  return n < 2 ? n : fibo(n - 1) + fibo(n - 2);
+}
+\end{ffcode}
+
+\END

--- a/testfiles/acmart.tlg
+++ b/testfiles/acmart.tlg
@@ -1,0 +1,2 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.


### PR DESCRIPTION
The `listings` package wraps every code display in `\@vspace`. The
`acmart` class redefines that macro to warn whenever it is called
outside a float, so every `ffcode` and `\ffinput` block in an acmart
paper produces a spurious "vspace should only be used" warning.

This adds a `DisplayStyle` hook that restores the originals acmart
saved (`\@vspace@orig`/`\@vspacer@orig`) while a listing is typeset.
It is guarded on those macros being defined, so it does nothing under
classes that never touch `\@vspace`. Until now every author had to
paste the same workaround into their preamble.

The regression test emulates acmart's `\vspace` guard rather than
loading the whole class, which keeps the expected log small and stable
across TeX Live versions and engines.

Closes #102