### PR TITLE
Size ffcolumnbreak columns by their longest line

### DIFF
--- a/ffcode.dtx
+++ b/ffcode.dtx
@@ -207,7 +207,9 @@
 % placing |\ffcolumnbreak| on a line of its own, wrapped in an escape so
 % that |listings| does not print it. Line numbering runs continuously
 % across the columns, which is handy for a listing too tall for the
-% page. Each further |\ffcolumnbreak| adds one more column:
+% page. Each further |\ffcolumnbreak| adds one more column. Every column
+% is sized to the longest line it holds, so columns of unequal length are
+% packed tightly rather than each taking an equal share of the line:
 % \docshotOptions{firstline=6,lastline=14}
 % \begin{docshot}
 % \documentclass{article}
@@ -359,16 +361,23 @@
 % splits an |ffcode| block into side-by-side columns. Because |listings|
 % typesets a single line-by-line stream, a block is first captured
 % verbatim to a temporary file; that file is then scanned for
-% |\ffcolumnbreak| markers, and each segment between two markers is
-% typeset in its own |\parbox|, separated by a thin gray rule. A block
-% without any marker is rendered as one listing, exactly as before:
+% |\ffcolumnbreak| markers, which cut it into segments. Each segment is
+% measured before it is printed: it is typeset once into a discarded box,
+% so that |listings| records the width of its longest line in
+% |\lst@maxwidth|, and that width (plus the gutter reserved for line
+% numbers) becomes the natural width of the column. When the natural
+% widths and the separating rules fit within |\linewidth|, every column
+% takes its own natural width, so a narrow column no longer claims an
+% equal share of the line; otherwise the widths are scaled down in
+% proportion to fit. A block without any marker is rendered as one
+% listing, exactly as before:
 % \changes{v0.13.0}{2026/07/10}{The \texttt{\char`\\ffcolumnbreak} marker added, to split an \texttt{ffcode} block into two or more side-by-side columns.}
+% \changes{v0.14.0}{2026/07/10}{Columns split by \texttt{\char`\\ffcolumnbreak} are now sized by the longest line in each, instead of splitting \texttt{\char`\\linewidth} evenly.}
 %    \begin{macrocode}
 \RequirePackage{fancyvrb}
 \makeatletter
 \newcommand\ffcolumnbreak{}
 \edef\ff@cbmarker{\string\ffcolumnbreak}
-\def\ff@empty{}
 \newread\ff@read
 \newcount\ff@nlines
 \newcount\ff@nbreaks
@@ -376,14 +385,14 @@
 \newcount\ff@prev
 \newdimen\ff@colwd
 \newdimen\ff@sepwd
+\newdimen\ff@total
+\newdimen\ff@avail
+\newdimen\ff@natwd
+\newdimen\ff@gutter
+\newsavebox\ff@mbox
+\let\ff@grab\relax
+\lst@AddToHook{Init}{\ff@grab}
 \def\ff@colsep{\hspace{0.4em}{\color{gray}\vrule width 0.3pt}\hspace{0.4em}}
-\def\ff@colbox#1#2{%
-  \parbox[t]{\ff@colwd}{\vspace{0pt}%
-    \lstinputlisting[firstline=#1,lastline=#2]{\ff@file}}}
-\protected\def\ff@mark#1{%
-  \ifnum\ff@prev=\z@\else\ff@colsep\fi
-  \ff@colbox{\the\numexpr\ff@prev+\@ne\relax}{\the\numexpr#1-\@ne\relax}%
-  \ff@prev=#1\relax}
 \def\ff@allother{%
   \count@=\z@
   \loop\catcode\count@=12 \ifnum\count@<255 \advance\count@\@ne\repeat
@@ -397,30 +406,59 @@
     \edef\ff@call{\noexpand\in@{\ff@cbmarker}{\ff@line}}\ff@call
     \ifin@
       \global\advance\ff@nbreaks\@ne
-      \xdef\ff@breaks{\ff@breaks\noexpand\ff@mark{\the\ff@nlines}}%
+      \xdef\ff@segs{\unexpanded\expandafter{\ff@segs}\noexpand\ff@seg
+        {\the\numexpr\ff@prev+\@ne\relax}{\the\numexpr\ff@nlines-\@ne\relax}}%
+      \global\ff@prev=\ff@nlines
     \fi
     \let\ff@next\ff@readloop
   \fi
   \ff@next}
 \def\ff@scan{%
-  \global\ff@nlines=\z@ \global\ff@nbreaks=\z@ \gdef\ff@breaks{}%
+  \global\ff@nlines=\z@ \global\ff@nbreaks=\z@
+  \global\ff@prev=\z@ \gdef\ff@segs{}%
   \openin\ff@read=\ff@file\relax
   \begingroup\ff@allother\ff@readloop\endgroup
-  \closein\ff@read}
+  \closein\ff@read
+  \ifnum\ff@nbreaks>\z@
+    \xdef\ff@segs{\unexpanded\expandafter{\ff@segs}\noexpand\ff@seg
+      {\the\numexpr\ff@prev+\@ne\relax}{\the\ff@nlines}}%
+  \fi}
+\def\ff@measure#1#2{%
+  \setbox\ff@mbox=\vbox{\hfuzz\maxdimen
+    \lstinputlisting[numbers=none,breaklines=false,%
+      firstline=#1,lastline=#2]{\ff@file}}%
+  \ff@natwd=\dimexpr\lst@maxwidth+\ff@gutter\relax
+  \global\advance\ff@total\ff@natwd
+  \xdef\ff@cols{\unexpanded\expandafter{\ff@cols}%
+    \noexpand\ff@col{#1}{#2}{\the\ff@natwd}}}
+\def\ff@col#1#2#3{%
+  \ifnum\ff@prev=\z@\else\ff@colsep\fi
+  \ifdim\ff@total>\ff@avail
+    \ff@colwd=\dimexpr#3*\number\ff@avail/\number\ff@total\relax
+  \else
+    \ff@colwd=#3\relax
+  \fi
+  \parbox[t]{\ff@colwd}{\vspace{0pt}%
+    \lstinputlisting[firstline=#1,lastline=#2]{\ff@file}}%
+  \ff@prev=\@ne}
 \def\ff@render{%
   \ff@scan
   \begingroup
   \expandafter\lstset\expandafter{\ff@opts}%
-  \ifx\ff@breaks\ff@empty
+  \ifnum\ff@nbreaks=\z@
     \lstinputlisting{\ff@file}%
   \else
     \ff@ncols=\ff@nbreaks \advance\ff@ncols\@ne
     \ff@sepwd=0.8em \advance\ff@sepwd0.3pt
-    \ff@colwd=\dimexpr(\linewidth-\ff@sepwd*\ff@ncols+\ff@sepwd)/\ff@ncols\relax
+    \ff@avail=\dimexpr\linewidth-\ff@sepwd*\ff@ncols+\ff@sepwd\relax
+    \global\ff@total=\z@ \gdef\ff@cols{}%
+    \edef\ff@savednum{\the\c@lstnumber}%
+    \def\ff@grab{\global\ff@gutter\@totalleftmargin}%
+    \let\ff@seg\ff@measure \ff@segs
+    \let\ff@grab\relax
+    \global\c@lstnumber=\ff@savednum\relax
     \par\addvspace\topsep
-    \noindent\hbox{%
-      \ff@prev=\z@ \ff@breaks \ff@colsep
-      \ff@colbox{\the\numexpr\ff@prev+\@ne\relax}{\the\ff@nlines}}%
+    \noindent\hbox{\ff@prev=\z@ \ff@cols}%
     \par\addvspace\topsep
   \fi
   \endgroup}

--- a/testfiles/columns.luatex.tlg
+++ b/testfiles/columns.luatex.tlg
@@ -1,5 +1,6 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-(columns.ffcode) (columns.ffcode)
-(columns.ffcode) (columns.ffcode) (columns.ffcode)
+(columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode)
+(columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode)
 (columns.ffcode)
+(columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode)

--- a/testfiles/columns.lvt
+++ b/testfiles/columns.lvt
@@ -34,4 +34,12 @@ A plain block, without any break, still renders as one listing:
 int x = 1;
 \end{ffcode}
 
+Columns wider than the line are shrunk in proportion to fit:
+
+\begin{ffcode}
+a very long first column that on its own already fills the whole text width
+(*@ \ffcolumnbreak @*)
+an even longer second column that certainly cannot fit beside the first one at all
+\end{ffcode}
+
 \END

--- a/testfiles/columns.tlg
+++ b/testfiles/columns.tlg
@@ -1,5 +1,6 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-(columns.ffcode) (columns.ffcode)
-(columns.ffcode) (columns.ffcode) (columns.ffcode)
+(columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode)
+(columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode)
 (columns.ffcode)
+(columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode)

--- a/testfiles/columns.xetex.tlg
+++ b/testfiles/columns.xetex.tlg
@@ -1,5 +1,6 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-(columns.ffcode) (columns.ffcode)
-(columns.ffcode) (columns.ffcode) (columns.ffcode)
+(columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode)
+(columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode)
 (columns.ffcode)
+(columns.ffcode) (columns.ffcode) (columns.ffcode) (columns.ffcode)

--- a/testfiles/tmpfile.luatex.tlg
+++ b/testfiles/tmpfile.luatex.tlg
@@ -1,3 +1,3 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-(ffscratch.tmp) (ffscratch.tmp)
+(ffscratch.tmp) (ffscratch.tmp) (ffscratch.tmp) (ffscratch.tmp)

--- a/testfiles/tmpfile.tlg
+++ b/testfiles/tmpfile.tlg
@@ -1,3 +1,3 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-(ffscratch.tmp) (ffscratch.tmp)
+(ffscratch.tmp) (ffscratch.tmp) (ffscratch.tmp) (ffscratch.tmp)

--- a/testfiles/tmpfile.xetex.tlg
+++ b/testfiles/tmpfile.xetex.tlg
@@ -1,3 +1,3 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-(ffscratch.tmp) (ffscratch.tmp)
+(ffscratch.tmp) (ffscratch.tmp) (ffscratch.tmp) (ffscratch.tmp)


### PR DESCRIPTION
Columns split by `\ffcolumnbreak` no longer share `\linewidth` in equal
slices. Each segment is measured first: the block is typeset once into a
discarded box so `listings` records the width of its longest line, and
that width plus the line-number gutter becomes the column's natural
width. When the columns and their separating rules fit within
`\linewidth`, each keeps its natural width; when the row is too wide,
the widths are scaled down in proportion so they still fit.

Before this, a short column claimed as much of the line as a wide one,
which wasted space and forced the wide column to wrap needlessly. Line
numbering stays continuous across the columns, unchanged.

The measurement pass reads the scratch file once more per column, which
is why the `columns` and `tmpfile` regression baselines gained extra
file-open echoes. A new case in `columns.lvt` covers the proportional
shrink path.

Closes #105