### PR TITLE
Restore \vspace guard inside \ffcolumnbreak columns

### DIFF
--- a/ffcode.dtx
+++ b/ffcode.dtx
@@ -373,6 +373,7 @@
 % listing, exactly as before:
 % \changes{v0.13.0}{2026/07/10}{The \texttt{\char`\\ffcolumnbreak} marker added, to split an \texttt{ffcode} block into two or more side-by-side columns.}
 % \changes{v0.14.0}{2026/07/10}{Columns split by \texttt{\char`\\ffcolumnbreak} are now sized by the longest line in each, instead of splitting \texttt{\char`\\linewidth} evenly.}
+% \changes{v0.14.1}{2026/07/10}{Restore the original \texttt{\char`\\@vspace} inside every \texttt{\char`\\ffcolumnbreak} column, so \texttt{acmart} no longer warns about the top-alignment strut in each column box.}
 %    \begin{macrocode}
 \RequirePackage{fancyvrb}
 \makeatletter
@@ -438,7 +439,9 @@
   \else
     \ff@colwd=#3\relax
   \fi
-  \parbox[t]{\ff@colwd}{\vspace{0pt}%
+  \parbox[t]{\ff@colwd}{%
+    \ifdefined\@vspace@orig\let\@vspace\@vspace@orig\fi
+    \vspace{0pt}%
     \lstinputlisting[firstline=#1,lastline=#2]{\ff@file}}%
   \ff@prev=\@ne}
 \def\ff@render{%

--- a/ffcode.dtx
+++ b/ffcode.dtx
@@ -440,7 +440,10 @@
     \ff@colwd=#3\relax
   \fi
   \parbox[t]{\ff@colwd}{%
-    \ifdefined\@vspace@orig\let\@vspace\@vspace@orig\fi
+    \ifdefined\@vspace@orig
+      \let\@vspace\@vspace@orig
+      \ifdefined\@vspacer@orig\let\@vspacer\@vspacer@orig\fi
+    \fi
     \vspace{0pt}%
     \lstinputlisting[firstline=#1,lastline=#2]{\ff@file}}%
   \ff@prev=\@ne}

--- a/testfiles/acmart-columns.lvt
+++ b/testfiles/acmart-columns.lvt
@@ -1,0 +1,30 @@
+% SPDX-FileCopyrightText: Copyright (c) 2021-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+% This test emulates the \vspace guard that acmart installs (its
+% \@vspace@orig machinery, see acmart.cls) instead of loading the whole
+% class, so that the expected log stays small and stable across TeX Live
+% versions. It fails when a \ffcolumnbreak block lets its \parbox strut
+% trip that guard (issue #106).
+
+\input{regression-test.tex}
+\documentclass{article}
+\usepackage{etoolbox}
+\makeatletter
+\let\@vspace@orig=\@vspace
+\let\@vspacer@orig=\@vspacer
+\apptocmd{\@vspace}{\ClassWarning{acmart}{\string\vspace\space should only be used}}{}{}
+\apptocmd{\@vspacer}{\ClassWarning{acmart}{\string\vspace\space should only be used}}{}{}
+\makeatother
+\usepackage[nocn,nonumbers,noframes]{ffcode}
+\begin{document}
+
+\START
+
+\begin{ffcode}
+Hello, world!
+(*@ \ffcolumnbreak @*)
+Bye!
+\end{ffcode}
+
+\END

--- a/testfiles/acmart-columns.tlg
+++ b/testfiles/acmart-columns.tlg
@@ -1,0 +1,3 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+(acmart-columns.ffcode) (acmart-columns.ffcode) (acmart-columns.ffcode) (acmart-columns.ffcode)


### PR DESCRIPTION
Under `acmart`, every `ffcode` block containing a `\ffcolumnbreak` emitted `Class acmart Warning: \vspace should only be used...`, once per rendered column. Each column typesets its listing inside a `\parbox[t]` whose `\vspace{0pt}` top-alignment strut fired before `\lstinputlisting` triggered the `listings` `DisplayStyle` hook, and it is that hook which restores acmart's saved `\@vspace@orig`. So on the column path acmart's warning-emitting `\@vspace` was still active when the strut expanded.

The fix restores `\@vspace@orig` inside the column box, right before the strut, using the same technique the `DisplayStyle` hook already uses. This is a regression of #102 (fixed in v0.12.2) reintroduced by the `\ffcolumnbreak` feature in v0.13.0.

Added `acmart-columns.lvt`, which reproduces the warning with the same lightweight acmart guard emulation as the existing `acmart` test but on a two-column block. The full l3build suite passes on pdftex, luatex, and xetex.

Closes #106